### PR TITLE
Changes in install generator + some refactoring

### DIFF
--- a/lib/generators/protocolist/install/install_generator.rb
+++ b/lib/generators/protocolist/install/install_generator.rb
@@ -39,7 +39,7 @@ module Protocolist
         invoke "mongoid:model", [model_classname]
         
         if model_exists?
-          inject_into_file(model_filename, content, :after => "include Mongoid::Document\n")
+          inject_into_file(model_filename, content, after: "include Mongoid::Document\n")
         end
       end
       
@@ -55,7 +55,7 @@ module Protocolist
         
         
         migration_template "migration.rb", "db/migrate/create_activities"
-        invoke "active_record:model", [model_classname], :migration => false
+        invoke "active_record:model", [model_classname], migration: false
         
         if model_exists?
           gsub_file model_filename, / +# attr_accessible :title, :body\n/, ''

--- a/lib/protocolist.rb
+++ b/lib/protocolist.rb
@@ -10,8 +10,8 @@ require 'protocolist/railtie' if defined? Rails
 module Protocolist
 
   def self.fire(activity_type, options = {})
-    options = { :actor => @actor, :activity_type => activity_type }.merge options
-    @activity_class.create options if options[:actor] && @activity_class
+    options = { actor: @actor, activity_type: activity_type }.merge options
+    @activity_class.try(:create, options) if options[:actor]
   end
   
   class << self

--- a/lib/protocolist/controller_additions.rb
+++ b/lib/protocolist/controller_additions.rb
@@ -25,7 +25,7 @@ module Protocolist
         options_for_fire     = options.except(:if, :unless, :only, :except)
 
         callback_proc = lambda do |controller|
-          controller.fire(activity_type, options_for_fire.merge(:data => data_proc.call(controller)))
+          controller.fire(activity_type, options_for_fire.merge(data: data_proc.call(controller)))
         end
 
         send(:after_filter, callback_proc, options_for_callback)

--- a/lib/protocolist/controller_additions.rb
+++ b/lib/protocolist/controller_additions.rb
@@ -1,10 +1,12 @@
 require 'protocolist/controller_additions/initializer'
+require 'protocolist/util/data_proc'
 
 module Protocolist
   module ControllerAdditions
     extend ActiveSupport::Concern
     include Initializer
-    
+    include Util::DataProc
+
     def fire(activity_type = nil, options = {})
       options[:target] = instance_variable_get("@#{controller_name.singularize}") if options[:target] == nil
       options[:target] = nil if options[:target] == false
@@ -27,18 +29,6 @@ module Protocolist
         end
 
         send(:after_filter, callback_proc, options_for_callback)
-      end
-      
-      private
-      
-      def extract_data_proc(data)
-        if data.respond_to? :call
-          lambda {|controller| data.call(controller) }
-        elsif data.is_a? Symbol
-          lambda {|controller| controller.send(data) }
-        else
-          lambda {|record| data }
-        end
       end
     end
   end

--- a/lib/protocolist/model_additions.rb
+++ b/lib/protocolist/model_additions.rb
@@ -5,7 +5,7 @@ module Protocolist
     extend ActiveSupport::Concern
     include Util::DataProc
     
-    def fire(activity_type, options={})
+    def fire(activity_type, options = {})
       options[:target] = self if options[:target] == nil
       options[:target] = nil  if options[:target] == false
 
@@ -13,7 +13,7 @@ module Protocolist
     end
     
     module ClassMethods
-      def fires(activity_type, options={})
+      def fires(activity_type, options = {})
         fires_on  = [*options[:on] || activity_type]
         data_proc = extract_data_proc options[:data]
 
@@ -21,7 +21,7 @@ module Protocolist
         options_for_fire     = options.except(:if, :unless, :on)
 
         callback_proc = lambda do |record|
-          record.fire(activity_type, options_for_fire.merge(:data => data_proc.call(record)))
+          record.fire(activity_type, options_for_fire.merge(data: data_proc.call(record)))
         end
 
         fires_on.each do |on|

--- a/lib/protocolist/model_additions.rb
+++ b/lib/protocolist/model_additions.rb
@@ -1,6 +1,9 @@
+require 'protocolist/util/data_proc'
+
 module Protocolist
   module ModelAdditions
     extend ActiveSupport::Concern
+    include Util::DataProc
     
     def fire(activity_type, options={})
       options[:target] = self if options[:target] == nil
@@ -23,18 +26,6 @@ module Protocolist
 
         fires_on.each do |on|
           send("after_#{on}", callback_proc, options_for_callback)
-        end
-      end
-      
-      private
-      
-      def extract_data_proc(data)
-        if data.respond_to? :call
-          lambda {|record| data.call record }
-        elsif data.is_a? Symbol
-          lambda {|record| record.send data }
-        else
-          lambda {|record| data }
         end
       end
     end

--- a/lib/protocolist/util/data_proc.rb
+++ b/lib/protocolist/util/data_proc.rb
@@ -1,0 +1,21 @@
+module Protocolist
+  module Util
+    module DataProc
+      extend ActiveSupport::Concern
+      
+      module ClassMethods
+        private
+        
+        def extract_data_proc(data)
+          if data.respond_to? :call
+            lambda {|o| data.call(o) }
+          elsif data.is_a? Symbol
+            lambda {|o| o.send(data) }
+          else
+            lambda {|_| data }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/protocolist/controller_additions_spec.rb
+++ b/spec/protocolist/controller_additions_spec.rb
@@ -1,13 +1,5 @@
 require "spec_helper"
 
-class User < SuperModel::Base
-
-end
-
-class Activity < SuperModel::Base
-
-end
-
 class FirestartersController
   #stub before filter
   def self.before_filter *args
@@ -15,46 +7,51 @@ class FirestartersController
 
   include Protocolist::ControllerAdditions
   
-  def explicit_use
-    fire :gogogo, :target => User.new(:name => 'Lisa'), :data => '<3 <3 <3'
+  def explicit_use(target, data)
+    fire :gogogo, :target => target, :data => data
   end
 
-  def implicit_use
-    @firestarter = User.new(:name => 'Marge')
+  def implicit_use(target)
+    @firestarter = target
     fire
   end
 end
 
 describe Protocolist::ControllerAdditions do
+  let(:controller) { FirestartersController.new }
+  let(:actor) { User.new(:name => 'Bill') }
+  let(:lisa)  { User.new(:name => 'Lisa') }
+  let(:mary)  { User.new(:name => 'Mary') }
+  
   before :each do
     Activity.destroy_all
-    user = User.new(:name => 'Bill')
-    @controller = FirestartersController.new
 
-    @controller.stub(:current_user){user}
-    @controller.stub(:controller_name){'firestarters'}
-    @controller.stub(:action_name){'quick_and_dirty_action_stub'}
-    @controller.stub(:params){'les params'}
+    controller.stub(:current_user).and_return actor
+    controller.stub(:controller_name).and_return 'firestarters'
+    controller.stub(:action_name).and_return 'quick_and_dirty_action_stub'
+    controller.stub(:params).and_return 'les params'
 
-    @controller.initialize_protocolist
+    controller.initialize_protocolist
   end
 
   describe 'direct fire method call' do
     it 'saves record with target and data when called explicitly' do
-      @controller.explicit_use
+      controller.explicit_use(lisa, '<3 <3 <3')
 
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :gogogo
-      Activity.last.target.name.should == 'Lisa'
-      Activity.last.data.should == '<3 <3 <3'
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :gogogo
+      activity.target.should        == lisa
+      activity.data.should          == '<3 <3 <3'
     end
 
     it 'saves record with target and data when called implicitly' do
-      @controller.implicit_use
+      controller.implicit_use(mary)
 
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :quick_and_dirty_action_stub
-      Activity.last.target.name.should == 'Marge'
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :quick_and_dirty_action_stub
+      activity.target.should        == mary
     end
   end
 
@@ -62,36 +59,35 @@ describe Protocolist::ControllerAdditions do
     it 'saves record when called with minimal options' do
       FirestartersController.should_receive(:after_filter) do |callback_proc, options|
         options[:only].should == :download
-
-        expect {
-          callback_proc.call(@controller)
-        }.to change{Activity.count}.by 1
-        Activity.last.actor.name.should == 'Bill'
-        Activity.last.activity_type.should == :download
-        Activity.last.target.should_not be
+        expect { callback_proc.call(controller) }.to change{ Activity.count }.by 1
+        
+        activity = Activity.last
+        activity.actor.should         == actor
+        activity.activity_type.should == :download
+        activity.target.should_not be
       end
+      
       FirestartersController.send(:fires, :download)
     end
 
     it 'saves record when called with complex options' do
       FirestartersController.should_receive(:after_filter) do |callback_proc, options|
         options[:only].should == [:download_report, :download_file, :download_map]
-        options[:if].should == 'if condition'
+        options[:if].should   == 'if condition'
 
-        expect {
-          callback_proc.call(@controller)
-        }.to change{Activity.count}.by 1
+        expect { callback_proc.call(controller) }.to change{ Activity.count }.by 1
 
-        Activity.last.actor.name.should == 'Bill'
-        Activity.last.activity_type.should == :download
-        Activity.last.data.should == 'les params'
-        Activity.last.target.should_not be
+        activity = Activity.last
+        activity.actor.should         == actor
+        activity.activity_type.should == :download
+        activity.data.should          == 'les params'
+        activity.target.should_not be
       end
 
-      FirestartersController.send(:fires, :download,
-                                  :only => [:download_report, :download_file, :download_map],
-                                  :data => lambda{|c| c.params },
-                                  :if => 'if condition')
+      FirestartersController.send(:fires, :download, 
+        :only => [:download_report, :download_file, :download_map],
+        :data => lambda {|c| c.params }, :if => 'if condition'
+      )
     end
   end
 end

--- a/spec/protocolist/controller_additions_spec.rb
+++ b/spec/protocolist/controller_additions_spec.rb
@@ -8,7 +8,7 @@ class FirestartersController
   include Protocolist::ControllerAdditions
   
   def explicit_use(target, data)
-    fire :gogogo, :target => target, :data => data
+    fire :gogogo, target: target, data: data
   end
 
   def implicit_use(target)
@@ -19,9 +19,9 @@ end
 
 describe Protocolist::ControllerAdditions do
   let(:controller) { FirestartersController.new }
-  let(:actor) { User.new(:name => 'Bill') }
-  let(:lisa)  { User.new(:name => 'Lisa') }
-  let(:mary)  { User.new(:name => 'Mary') }
+  let(:actor) { User.new(name: 'Bill') }
+  let(:lisa)  { User.new(name: 'Lisa') }
+  let(:mary)  { User.new(name: 'Mary') }
   
   before :each do
     Activity.destroy_all
@@ -85,8 +85,8 @@ describe Protocolist::ControllerAdditions do
       end
 
       FirestartersController.send(:fires, :download, 
-        :only => [:download_report, :download_file, :download_map],
-        :data => lambda {|c| c.params }, :if => 'if condition'
+        only: [:download_report, :download_file, :download_map],
+        data: lambda {|c| c.params }, if: 'if condition'
       )
     end
   end

--- a/spec/protocolist/model_additions_spec.rb
+++ b/spec/protocolist/model_additions_spec.rb
@@ -4,7 +4,7 @@ class Firestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
   def delete
-    fire :delete, :target => false
+    fire :delete, target: false
   end
 
   def myself
@@ -12,7 +12,7 @@ class Firestarter < SuperModel::Base
   end
 
   def love_letter_for_mary(target, data)
-    fire :love_letter, :target => target, :data => data
+    fire :love_letter, target: target, data: data
   end
 end
 
@@ -24,8 +24,8 @@ end
 class ConditionalFirestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
-  fires :i_will_be_saved, :on => :create, :if => :return_true_please
-  fires :and_i_won_t,     :on => :create, :if => :return_false_please
+  fires :i_will_be_saved, on: :create, if: :return_true_please
+  fires :and_i_won_t,     on: :create, if: :return_false_please
 
   def return_false_please
     false
@@ -39,7 +39,7 @@ end
 class ComplexFirestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
-  fires :yohoho, :on => [:create, :destroy], :target => false, :data => :hi
+  fires :yohoho, on: [:create, :destroy], target: false, data: :hi
 
   def hi
     'Hi!'
@@ -47,8 +47,8 @@ class ComplexFirestarter < SuperModel::Base
 end
 
 describe Protocolist::ModelAdditions do
-  let(:actor) { User.new(:name => 'Bill') }
-  let(:mary) { User.new(:name => 'Mary') }
+  let(:actor) { User.new(name: 'Bill') }
+  let(:mary) { User.new(name: 'Mary') }
   
   before do
     Activity.destroy_all  
@@ -91,7 +91,7 @@ describe Protocolist::ModelAdditions do
 
   describe 'fires callback' do
     it 'saves record when called with minimal options' do
-      expect { SimpleFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+      expect { SimpleFirestarter.create(name: 'Ted') }.to change{ Activity.count }.by 1
       
       activity = Activity.last
       activity.actor.should         == actor
@@ -103,7 +103,7 @@ describe Protocolist::ModelAdditions do
 
       #first create record
 
-      expect { ComplexFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+      expect { ComplexFirestarter.create(name: 'Ted') }.to change{ Activity.count }.by 1
 
       activity = Activity.last
       activity.actor.should         == actor
@@ -123,7 +123,7 @@ describe Protocolist::ModelAdditions do
     end
 
     it 'saves checks conditions' do
-      expect { ConditionalFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+      expect { ConditionalFirestarter.create(name: 'Ted') }.to change{ Activity.count }.by 1
       
       activity = Activity.last
       activity.actor.should         == actor

--- a/spec/protocolist/model_additions_spec.rb
+++ b/spec/protocolist/model_additions_spec.rb
@@ -1,13 +1,5 @@
 require "spec_helper"
 
-class User < SuperModel::Base
-
-end
-
-class Activity < SuperModel::Base
-
-end
-
 class Firestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
@@ -19,15 +11,13 @@ class Firestarter < SuperModel::Base
     fire :myself
   end
 
-  def love_letter_for_mary
-    user = User.create(:name => 'Mary')
-    fire :love_letter, :target => user, :data => '<3 <3 <3'
+  def love_letter_for_mary(target, data)
+    fire :love_letter, :target => target, :data => data
   end
 end
 
 class SimpleFirestarter < SuperModel::Base
   include Protocolist::ModelAdditions
-
   fires :create
 end
 
@@ -35,7 +25,7 @@ class ConditionalFirestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
   fires :i_will_be_saved, :on => :create, :if => :return_true_please
-  fires :and_i_won_t, :on => :create, :if => :return_false_please
+  fires :and_i_won_t,     :on => :create, :if => :return_false_please
 
   def return_false_please
     false
@@ -49,7 +39,7 @@ end
 class ComplexFirestarter < SuperModel::Base
   include Protocolist::ModelAdditions
 
-  fires :yohoho, :on =>[:create, :destroy], :target => false, :data => :hi
+  fires :yohoho, :on => [:create, :destroy], :target => false, :data => :hi
 
   def hi
     'Hi!'
@@ -57,85 +47,87 @@ class ComplexFirestarter < SuperModel::Base
 end
 
 describe Protocolist::ModelAdditions do
-  before :each do
-    Activity.destroy_all
-    @actor = User.new(:name => 'Bill')
-    Protocolist.actor = @actor
+  let(:actor) { User.new(:name => 'Bill') }
+  let(:mary) { User.new(:name => 'Mary') }
+  
+  before do
+    Activity.destroy_all  
+
+    Protocolist.actor = actor
     Protocolist.activity_class = Activity
   end
 
   describe 'direct fire method call' do
-    before :each do
-      @firestarter = Firestarter.new
-    end
+    let(:firestarter) { Firestarter.new }
 
     it 'saves record with target and data' do
-      expect {
-        @firestarter.love_letter_for_mary
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :love_letter
-      Activity.last.target.name.should == 'Mary'
-      Activity.last.data.should == '<3 <3 <3'
+      expect { firestarter.love_letter_for_mary(mary, '<3 <3 <3') }.to change{ Activity.count }.by 1
+
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :love_letter
+      activity.target.should        == mary
+      activity.data.should          == '<3 <3 <3'
     end
 
     it 'saves record with self as target if target is not set' do
-      expect {
-        @firestarter.myself
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :myself
-      Activity.last.target.should == @firestarter
+      expect { firestarter.myself }.to change{ Activity.count }.by 1
+      
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :myself
+      activity.target.should        == firestarter
     end
 
     it 'saves record without target if target set to false' do
-      expect {
-        @firestarter.delete
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :delete
-      Activity.last.target.should be_false
+      expect { firestarter.delete }.to change{ Activity.count }.by 1
+      
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :delete
+      activity.target.should        be_false
     end
   end
 
   describe 'fires callback' do
     it 'saves record when called with minimal options' do
-      expect {
-        SimpleFirestarter.create(:name => 'Ted')
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :create
-      Activity.last.target.name.should == 'Ted'
+      expect { SimpleFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+      
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :create
+      activity.target.name.should   == 'Ted'
     end
 
     it 'saves record when called with complex options' do
 
       #first create record
 
-      expect {
-          ComplexFirestarter.create(:name => 'Ted')
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :yohoho
-      Activity.last.target.should_not be
-      Activity.last.data.should == 'Hi!'
+      expect { ComplexFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :yohoho
+      activity.target.should_not be
+      activity.data.should == 'Hi!'
 
       #then destroy record
 
-      expect {
-        ComplexFirestarter.last.destroy
-      }.to change{Activity.count}.by 1
-      Activity.last.actor.name.should == 'Bill'
-      Activity.last.activity_type.should == :yohoho
-      Activity.last.target.should_not be
-      Activity.last.data.should == 'Hi!'
+      expect { ComplexFirestarter.last.destroy }.to change{ Activity.count }.by 1
+
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :yohoho
+      activity.target.should_not be
+      activity.data.should == 'Hi!'
     end
 
     it 'saves checks conditions' do
-      expect {
-        ConditionalFirestarter.create(:name => 'Ted')
-      }.to change{Activity.count}.by 1
-      Activity.last.activity_type.should == :i_will_be_saved
+      expect { ConditionalFirestarter.create(:name => 'Ted') }.to change{ Activity.count }.by 1
+      
+      activity = Activity.last
+      activity.actor.should         == actor
+      activity.activity_type.should == :i_will_be_saved
     end
   end
 

--- a/spec/protocolist_spec.rb
+++ b/spec/protocolist_spec.rb
@@ -9,46 +9,51 @@ class Activity < SuperModel::Base
 end
 
 describe Protocolist do
-  before :each do
+  let(:actor) { User.new(:name => 'Bill') }
+  let(:another_actor) { User.new(:name => 'Bob') }
+  let(:target) { User.new(:name => 'Mary') }
+  
+  before do
     Activity.destroy_all
-    @actor = User.new(:name => 'Bill')
-    Protocolist.actor = @actor
+    
+    Protocolist.actor = actor
     Protocolist.activity_class = Activity
   end
 
   it 'should silently skip saving if actor is falsy' do
     Protocolist.actor = nil
-    expect {Protocolist.fire :alarm}.not_to change{Activity.count}
-    expect {Protocolist.fire :alarm}.not_to raise_error
+    
+    expect { Protocolist.fire :alarm }.not_to change{ Activity.count }
+    expect { Protocolist.fire :alarm }.not_to raise_error
   end
 
   it 'should silently skip saving if activity_class is falsy' do
     Protocolist.activity_class = nil
-    expect {Protocolist.fire :alarm}.not_to change{Activity.count}
-    expect {Protocolist.fire :alarm}.not_to raise_error
+    
+    expect { Protocolist.fire :alarm }.not_to change{ Activity.count }
+    expect { Protocolist.fire :alarm }.not_to raise_error
   end
 
   it 'should save a simple record' do
-    expect {Protocolist.fire :alarm}.to change{Activity.count}.by 1
+    expect { Protocolist.fire :alarm }.to change{ Activity.count }.by 1
 
-    Activity.last.actor.should == @actor
-    Activity.last.activity_type.should == :alarm
+    activity = Activity.last
+    activity.actor.should         == actor
+    activity.activity_type.should == :alarm
   end
 
   it 'should save a complex record' do
-    another_actor = User.new(:name => 'Bob')
-    target = User.new(:name => 'Mary')
-
     expect {
       Protocolist.fire :alarm,
-      :actor => another_actor,
+      :actor  => another_actor,
       :target => target,
-      :data => {:some_attr => :some_data}
-    }.to change{Activity.count}.by 1
+      :data   => { :foo => :bar }
+    }.to change { Activity.count }.by 1
 
-    Activity.last.actor.name.should == 'Bob'
-    Activity.last.activity_type.should == :alarm
-    Activity.last.target.name.should == 'Mary'
-    Activity.last.data[:some_attr].should == :some_data
+    activity = Activity.last    
+    activity.actor.should         == another_actor
+    activity.activity_type.should == :alarm
+    activity.target.should        == target
+    activity.data[:foo].should    == :bar
   end
 end

--- a/spec/protocolist_spec.rb
+++ b/spec/protocolist_spec.rb
@@ -9,9 +9,9 @@ class Activity < SuperModel::Base
 end
 
 describe Protocolist do
-  let(:actor) { User.new(:name => 'Bill') }
-  let(:another_actor) { User.new(:name => 'Bob') }
-  let(:target) { User.new(:name => 'Mary') }
+  let(:actor) { User.new(name: 'Bill') }
+  let(:another_actor) { User.new(name: 'Bob') }
+  let(:target) { User.new(name: 'Mary') }
   
   before do
     Activity.destroy_all
@@ -43,12 +43,9 @@ describe Protocolist do
   end
 
   it 'should save a complex record' do
-    expect {
-      Protocolist.fire :alarm,
-      :actor  => another_actor,
-      :target => target,
-      :data   => { :foo => :bar }
-    }.to change { Activity.count }.by 1
+    expect do 
+      Protocolist.fire :alarm, actor: another_actor, target: target, data: { foo: :bar }
+    end.to change { Activity.count }.by 1
 
     activity = Activity.last    
     activity.actor.should         == another_actor

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@ require 'protocolist'
 require 'supermodel'
 Bundler.require(:default)
 
+User     = Class.new(SuperModel::Base)
+Activity = Class.new(SuperModel::Base)
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run :focus => true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,6 @@ Activity = Class.new(SuperModel::Base)
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.filter_run :focus => true
+  config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
I think that there should be an option in install generator. Choice between AR and MongoId should not be done just by checking if class is defined. What if I would like to use both AR and MongoId in my project?
- I extracted #extract_data_proc to module, because it's exactly the same in ModelAddition and ControllerAddition
